### PR TITLE
fix: dark mode toggle icon showing both sun and moon

### DIFF
--- a/_frontend/css/standards.css
+++ b/_frontend/css/standards.css
@@ -1062,4 +1062,9 @@
   .dark .provision-iso-link:hover {
     background: rgba(30, 58, 138, 0.5);
   }
+
+  .icon--sun { display: none; }
+  .icon--moon { display: block; }
+  html.dark .icon--sun { display: block; }
+  html.dark .icon--moon { display: none; }
 }

--- a/source/_pages/posts.adoc
+++ b/source/_pages/posts.adoc
@@ -1,3 +1,0 @@
----
-layout: posts
----


### PR DESCRIPTION
Fixes the dark/light mode toggle button displaying both sun and moon icons simultaneously. The icon visibility rules are now handled explicitly in CSS instead of relying on Tailwind utility classes that weren't being generated.