### PR TITLE
Fix nomenclature: categorize standards into three groups

### DIFF
--- a/script/discover_standards.rb
+++ b/script/discover_standards.rb
@@ -21,6 +21,7 @@ DELIVERABLES_URL = "https://isopublicstorageprod.blob.core.windows.net/opendata/
 
 DATA_DIR = File.expand_path("../source/_data", __dir__)
 YAML_PATH = File.join(DATA_DIR, "tc211_standards.yaml")
+PENDING_PATH = File.join(DATA_DIR, "tc211_standards_pending.yaml")
 
 REFERENCE_RE = %r{\A(?:ISO|ISO/TS|ISO/TR)\s+(\d+)(?:-(\d+))?:(\d{4})}
 SUPPLEMENT_RE = %r{/(Amd|Cor)\s}
@@ -68,7 +69,8 @@ def entry_from_deliverable(deliverable)
     "edition" => deliverable["edition"],
     "type" => deliverable["deliverableType"],
     "iso_id" => deliverable["id"],
-    "published" => deliverable["publicationDate"]
+    "published" => deliverable["publicationDate"],
+    "pending" => false
   }
 end
 
@@ -101,6 +103,14 @@ end
 inventory = latest.values
   .filter_map { |r| entry_from_deliverable(r) }
   .sort_by { |e| [e["number"].to_i, e["part"] || "\xff", e["edition"]] }
+
+# Apply pending list
+pending_refs = if File.exist?(PENDING_PATH)
+  Set.new((YAML.safe_load_file(PENDING_PATH) || []))
+else
+  Set.new
+end
+inventory.each { |e| e["pending"] = true if pending_refs.include?(e["reference"]) }
 
 # Identify new entries against existing inventory
 existing_refs = if File.exist?(YAML_PATH)

--- a/source/_data/tc211_standards_pending.yaml
+++ b/source/_data/tc211_standards_pending.yaml
@@ -1,0 +1,5 @@
+# Standards that do not define formal URI-identified requirements or conformance classes
+# in the ISO standard itself. Shown under "Standards Without Formal Requirements".
+# One standard reference per line (must match the reference field in tc211_standards.yaml).
+---
+- ISO 6709

--- a/source/_layouts/standard_index.html
+++ b/source/_layouts/standard_index.html
@@ -101,16 +101,24 @@ layout: default
   {% else %}
   <div class="documentation">
     <div class="standard-notice">
-      <h2>Awaiting Machine-Readable Data</h2>
+      {% if page.pending %}
+      <h2>Pending Data Upload</h2>
+      <p>
+        This standard does not define formal requirements or conformance classes
+        in the ISO standard itself.
+      </p>
+      {% else %}
+      <h2>Awaiting Data Upload</h2>
       <p>
         This ISO/TC 211 standard does not yet have machine-readable requirements
-        or conformance classes available on this site.
+        or conformance data on this site.
       </p>
       <p>
         Standards authors are invited to contribute requirements and conformance
         data in the YAML format described in
         <a href="https://github.com/ISO-TC211/standards.isotc211.org/blob/main/README.adoc">README.adoc</a>.
       </p>
+      {% endif %}
     </div>
   </div>
   {% endif %}

--- a/source/_plugins/standards/page_factory.rb
+++ b/source/_plugins/standards/page_factory.rb
@@ -22,7 +22,7 @@ module StandardsGenerator
       @site.pages << page
     end
 
-    def create_placeholder_page(entry)
+    def create_placeholder_page(entry, pending = false)
       std_key = entry["part"] ? "#{entry['number']}-#{entry['part']}" : entry["number"]
 
       data = {
@@ -30,11 +30,12 @@ module StandardsGenerator
         "title" => entry["title"],
         "standard_number" => std_key,
         "page_path" => std_key,
-        "description" => "This standard does not yet have machine-readable requirements " \
-                         "or conformance data on this site.",
+        "description" => pending ? "This standard does not define formal requirements or conformance classes." :
+          "This standard does not yet have machine-readable requirements or conformance data on this site.",
         "uri_base" => "#{entry['number']}/-#{entry['part'] || ''}/#{entry['edition']}/",
         "req_classes" => [],
         "conf_classes" => [],
+        "pending" => pending,
         "iso_standard_url" => "https://www.iso.org/standard/#{entry['iso_id']}.html"
       }
 

--- a/source/_plugins/standards_generator.rb
+++ b/source/_plugins/standards_generator.rb
@@ -43,6 +43,13 @@ module StandardsGenerator
 
       # Phase 2: placeholder standards from tc211_standards.yaml inventory
       tc211_path = File.join(site.source, "_data", "tc211_standards.yaml")
+      pending_path = File.join(site.source, "_data", "tc211_standards_pending.yaml")
+      pending_refs = if File.exist?(pending_path)
+        Set.new((YAML.safe_load_file(pending_path, permitted_classes: [Symbol]) || []))
+      else
+        Set.new
+      end
+
       if File.exist?(tc211_path)
         tc211_entries = YAML.safe_load_file(tc211_path, permitted_classes: [Symbol]) || []
         known_labels = catalog.map { |e| e["label"] }.to_set
@@ -50,7 +57,8 @@ module StandardsGenerator
         tc211_entries.each do |entry|
           next if known_labels.include?(entry["reference"])
 
-          factory.create_placeholder_page(entry)
+          pending = entry["pending"] || pending_refs.include?(entry["reference"])
+          factory.create_placeholder_page(entry, pending)
 
           std_key = entry["part"] ? "#{entry['number']}-#{entry['part']}" : entry["number"]
           catalog << {
@@ -62,6 +70,7 @@ module StandardsGenerator
             "req_count" => 0,
             "conf_count" => 0,
             "populated" => false,
+            "pending" => pending,
             "iso_standard_url" => "https://www.iso.org/standard/#{entry['iso_id']}.html"
           }
         end

--- a/source/index.html
+++ b/source/index.html
@@ -53,7 +53,8 @@ title: Home
 
 <!-- Standards Listing -->
 {% assign populated = site.data.standards_catalog | where_exp: "std", "std.populated == true" %}
-{% assign awaiting = site.data.standards_catalog | where_exp: "std", "std.populated != true" %}
+{% assign pending = site.data.standards_catalog | where_exp: "std", "std.populated != true and std.pending == true" %}
+{% assign awaiting = site.data.standards_catalog | where_exp: "std", "std.populated != true and std.pending != true" %}
 <section id="standards" class="section section--white">
   <div style="max-width: 80rem; margin: 0 auto;">
 
@@ -91,13 +92,47 @@ title: Home
     </div>
     {% endif %}
 
+    {% if pending.size > 0 %}
+    <div class="section__header" style="margin-top: 3rem;">
+      <span class="section__kicker">Pending</span>
+      <h2 class="section__title">Standards Without Formal Requirements</h2>
+      <p class="section__desc">
+        These ISO/TC 211 standards do not provide URI-identified requirements
+        or conformance classes in the ISO standard.
+      </p>
+    </div>
+
+    <div class="standards-catalog">
+      {% for std in pending %}
+      <a href="{{ std.url }}" class="standards-card">
+        <div class="standards-card__icon">
+          <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z"/>
+          </svg>
+        </div>
+        <div class="standards-card__body">
+          <h3 class="standards-card__title">{{ std.label }}</h3>
+          <p class="standards-card__desc">{{ std.subtitle }}</p>
+          <div class="standards-card__meta">
+            <span class="standards-card__badge">Edition {{ std.edition }}</span>
+            <span class="standards-card__count">No requirements defined</span>
+          </div>
+        </div>
+        <svg class="standards-card__chevron" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.25 4.5l7.5 7.5-7.5 7.5"/>
+        </svg>
+      </a>
+      {% endfor %}
+    </div>
+    {% endif %}
+
     {% if awaiting.size > 0 %}
     <div class="section__header" style="margin-top: 3rem;">
       <span class="section__kicker">Awaiting Data</span>
-      <h2 class="section__title">Standards Awaiting Data</h2>
+      <h2 class="section__title">Standards Awaiting Data Upload</h2>
       <p class="section__desc">
         These ISO/TC 211 standards have been identified but do not yet have
-        machine-readable requirements or conformance classes.
+        machine-readable requirements or conformance data uploaded to this site.
       </p>
     </div>
 


### PR DESCRIPTION
## Summary

Categorizes standards into three distinct groups with correct nomenclature:

1. **Provided** — Standards with URI-identified requirements classes and conformance classes
2. **Without formal requirements** — Standards that do NOT provide URI-identified req/conf (e.g., ISO 6709)
3. **Awaiting data upload** — Standards where data upload is pending

## Changes

- `source/index.html` — Split standards listing into three sections with correct labels
- `source/_layouts/standard_index.html` — Differentiate pending vs awaiting notices on individual pages
- `source/_plugins/standards_generator.rb` — Pass `pending` flag through to catalog entries and placeholder pages
- `source/_plugins/standards/page_factory.rb` — Accept `pending` parameter in `create_placeholder_page`
- `script/discover_standards.rb` — Apply `tc211_standards_pending.yaml` list to inventory
- `source/_data/tc211_standards_pending.yaml` — New file listing standards without formal URI-identified req/conf