### PR TITLE
Fix ISO 6709 appearing in wrong category

### DIFF
--- a/script/discover_standards.rb
+++ b/script/discover_standards.rb
@@ -110,7 +110,9 @@ pending_refs = if File.exist?(PENDING_PATH)
 else
   Set.new
 end
-inventory.each { |e| e["pending"] = true if pending_refs.include?(e["reference"]) }
+inventory.each do |e|
+  e["pending"] = true if pending_refs.any? { |p| e["reference"] == p || e["reference"].start_with?("#{p}:") }
+end
 
 # Identify new entries against existing inventory
 existing_refs = if File.exist?(YAML_PATH)

--- a/source/_data/tc211_standards_pending.yaml
+++ b/source/_data/tc211_standards_pending.yaml
@@ -2,4 +2,4 @@
 # in the ISO standard itself. Shown under "Standards Without Formal Requirements".
 # One standard reference per line (must match the reference field in tc211_standards.yaml).
 ---
-- ISO 6709
+- ISO 6709:2022

--- a/source/_plugins/standards_generator.rb
+++ b/source/_plugins/standards_generator.rb
@@ -57,7 +57,8 @@ module StandardsGenerator
         tc211_entries.each do |entry|
           next if known_labels.include?(entry["reference"])
 
-          pending = entry["pending"] || pending_refs.include?(entry["reference"])
+          ref = entry["reference"]
+          pending = entry["pending"] || pending_refs.any? { |p| ref == p || ref.start_with?("#{p}:") }
           factory.create_placeholder_page(entry, pending)
 
           std_key = entry["part"] ? "#{entry['number']}-#{entry['part']}" : entry["number"]


### PR DESCRIPTION
## Problem

ISO 6709:2022 was showing under "Standards Awaiting Data Upload" instead of "Standards Without Formal Requirements".

## Cause

The pending list in `tc211_standards_pending.yaml` listed `ISO 6709` but the inventory has `ISO 6709:2022`. The exact string match failed, so the pending flag was never set.

## Fix

- Updated the pending reference to `ISO 6709:2022`
- Changed matching to prefix-based so `ISO 6709` matches `ISO 6709:2022` (works with or without year suffix)
- Applied to both the Jekyll generator and the discover script