### PR TITLE
Fix wording for standards without harmonized URI requirements

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -61,9 +61,9 @@ Every ISO/TC 211 standard on this site falls into one of three categories:
 Data is provided as YAML files under `source/_data/{Standard}/{Part}/{Edition}/`.
 These appear under "Supported Standards" on the homepage.
 
-**Without Formal Requirements**:: Standards that do *not* define URI-identified requirements or conformance classes in the ISO standard.
+**Without Harmonized URI Requirements**:: Standards that do *not* specify requirements that utilize the ISO/TC 211 Harmonized URI scheme.
 Listed manually in `source/_data/tc211_standards_pending.yaml`.
-These appear under "Standards Without Formal Requirements".
+These appear under "Standards Without Harmonized URI Requirements".
 
 **Awaiting Data Upload**:: Standards where the ISO defines requirements/conformance classes but data has not yet been uploaded to this site.
 These appear automatically from the inventory and show under "Standards Awaiting Data Upload".
@@ -197,9 +197,9 @@ Verify key URIs resolve in `_site/`. The following are generated automatically:
 * **404 page links** for navigation back to available standards
 * **Example URIs** in the homepage URI format section
 
-== Marking a Standard as "Without Formal Requirements"
+== Marking a Standard as "Without Harmonized URI Requirements"
 
-If an ISO/TC 211 standard does not define URI-identified requirements classes or conformance classes, add its reference to `source/_data/tc211_standards_pending.yaml`:
+If an ISO/TC 211 standard does not specify requirements that utilize the ISO/TC 211 Harmonized URI scheme, add its reference to `source/_data/tc211_standards_pending.yaml`:
 
 [source,yaml]
 ----
@@ -209,7 +209,7 @@ If an ISO/TC 211 standard does not define URI-identified requirements classes or
 - ISO 6709:2022
 ----
 
-The standard will then appear under "Standards Without Formal Requirements" instead of "Awaiting Data Upload".
+The standard will then appear under "Standards Without Harmonized URI Requirements" instead of "Awaiting Data Upload".
 
 == Standards Inventory and Auto-Discovery
 

--- a/source/_data/tc211_standards_pending.yaml
+++ b/source/_data/tc211_standards_pending.yaml
@@ -1,5 +1,5 @@
-# Standards that do not define formal URI-identified requirements or conformance classes
-# in the ISO standard itself. Shown under "Standards Without Formal Requirements".
+# Standards that do not specify requirements that utilize the ISO/TC 211 Harmonized URI scheme.
+# Shown under "Standards Without Harmonized URI Requirements" on the homepage.
 # One standard reference per line (must match the reference field in tc211_standards.yaml).
 ---
 - ISO 6709:2022

--- a/source/_layouts/standard_index.html
+++ b/source/_layouts/standard_index.html
@@ -102,10 +102,10 @@ layout: default
   <div class="documentation">
     <div class="standard-notice">
       {% if page.pending %}
-      <h2>Pending Data Upload</h2>
+      <h2>No Harmonized URI Requirements</h2>
       <p>
-        This standard does not define formal requirements or conformance classes
-        in the ISO standard itself.
+        This standard does not specify requirements that utilize the
+        ISO/TC 211 Harmonized URI scheme.
       </p>
       {% else %}
       <h2>Awaiting Data Upload</h2>

--- a/source/_plugins/standards/page_factory.rb
+++ b/source/_plugins/standards/page_factory.rb
@@ -30,7 +30,7 @@ module StandardsGenerator
         "title" => entry["title"],
         "standard_number" => std_key,
         "page_path" => std_key,
-        "description" => pending ? "This standard does not define formal requirements or conformance classes." :
+        "description" => pending ? "This standard does not specify requirements that utilize the ISO/TC 211 Harmonized URI scheme." :
           "This standard does not yet have machine-readable requirements or conformance data on this site.",
         "uri_base" => "#{entry['number']}/-#{entry['part'] || ''}/#{entry['edition']}/",
         "req_classes" => [],

--- a/source/index.html
+++ b/source/index.html
@@ -95,10 +95,10 @@ title: Home
     {% if pending.size > 0 %}
     <div class="section__header" style="margin-top: 3rem;">
       <span class="section__kicker">Pending</span>
-      <h2 class="section__title">Standards Without Formal Requirements</h2>
+      <h2 class="section__title">Standards Without Harmonized URI Requirements</h2>
       <p class="section__desc">
-        These ISO/TC 211 standards do not provide URI-identified requirements
-        or conformance classes in the ISO standard.
+        These ISO/TC 211 standards do not specify requirements that utilize
+        the ISO/TC 211 Harmonized URI scheme.
       </p>
     </div>
 
@@ -115,7 +115,7 @@ title: Home
           <p class="standards-card__desc">{{ std.subtitle }}</p>
           <div class="standards-card__meta">
             <span class="standards-card__badge">Edition {{ std.edition }}</span>
-            <span class="standards-card__count">No requirements defined</span>
+            <span class="standards-card__count">No harmonized URI requirements</span>
           </div>
         </div>
         <svg class="standards-card__chevron" fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION
## Problem

The ISO 6709 page showed conflicting messages:
- Description: "This standard does not define formal requirements or conformance classes."
- Notice heading: "Pending Data Upload"
- Notice body: "This standard does not define formal requirements or conformance classes in the ISO standard itself."

## Fix

Use the correct phrasing everywhere: "This standard does not specify requirements that utilize the ISO/TC 211 Harmonized URI scheme."

Updated in: homepage section title/description, card badge, individual standard page notice heading/body, page description, README, and pending YAML comments.